### PR TITLE
Fix return type's namespace

### DIFF
--- a/src/Awjudd/FeedReader/FeedReader.php
+++ b/src/Awjudd/FeedReader/FeedReader.php
@@ -8,7 +8,7 @@ class FeedReader
     /**
      * Used to parse an RSS feed.
      * 
-     * @return SimplePie
+     * @return \SimplePie
      */
     public function read($url, $configuration = 'default')
     {


### PR DESCRIPTION
This fixes a small problem when I use with "barryvdh/laravel-ide-helper".

```bash
php artisan ide-helper:generate
```

Before:

```php
class FeedReader extends \Awjudd\FeedReader\Facades\FeedReader{
    	
    	/**
    	 * Used to parse an RSS feed.
    	 *
    	 * @return \Awjudd\FeedReader\SimplePie 
    	 * @static 
    	 */
    	public static function read($url, $configuration = 'default'){
    		return \Awjudd\FeedReader\FeedReader::read($url, $configuration);
    	}
    	
}
```

After:

```php
class FeedReader extends \Awjudd\FeedReader\Facades\FeedReader{
    	
    	/**
    	 * Used to parse an RSS feed.
    	 *
    	 * @return \SimplePie 
    	 * @static 
    	 */
    	public static function read($url, $configuration = 'default'){
    		return \Awjudd\FeedReader\FeedReader::read($url, $configuration);
    	}
    	
}
```